### PR TITLE
Allow sdk to use existent http session

### DIFF
--- a/datacosmos/config/config.py
+++ b/datacosmos/config/config.py
@@ -29,7 +29,6 @@ class Config(BaseSettings):
     authentication: Optional[AuthenticationConfig] = None
     stac: Optional[URL] = None
     datacosmos_cloud_storage: Optional[URL] = None
-    mission_id: int = 0
 
     DEFAULT_AUTH_TYPE: ClassVar[str] = "m2m"
     DEFAULT_AUTH_TOKEN_URL: ClassVar[str] = "https://login.open-cosmos.com/oauth/token"

--- a/datacosmos/datacosmos_client.py
+++ b/datacosmos/datacosmos_client.py
@@ -1,8 +1,4 @@
-"""DatacosmosClient handles authenticated interactions with the Datacosmos API.
-
-Automatically manages token refreshing and provides HTTP convenience
-methods.
-"""
+"""Client to interact with the Datacosmos API with authentication and request handling."""
 
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -19,23 +15,42 @@ from datacosmos.exceptions.datacosmos_exception import DatacosmosException
 class DatacosmosClient:
     """Client to interact with the Datacosmos API with authentication and request handling."""
 
-    def __init__(self, config: Optional[Config] = None):
+    def __init__(
+        self,
+        config: Optional[Config | Any] = None,
+        http_session: Optional[requests.Session] = None,
+    ):
         """Initialize the DatacosmosClient.
 
         Args:
-            config (Optional[Config]): Configuration object.
+            config (Optional[Config]): Configuration object (only needed when SDK creates its own session).
+            http_session (Optional[requests.Session]): Pre-authenticated session.
         """
-        if config:
+        if http_session is not None:
+            auth_header = http_session.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                raise DatacosmosException(
+                    "Injected session must include a 'Bearer' token in its headers"
+                )
+            self._http_client = http_session
+            self._owns_session = False
+            self.token = auth_header.split(" ", 1)[1]
+            self.token_expiry = None
+            # config will be provided by the same service that provides the http_session
             self.config = config
         else:
-            try:
-                self.config = Config.from_yaml()
-            except ValueError:
-                self.config = Config.from_env()
+            if config:
+                self.config = config
+            else:
+                try:
+                    self.config = Config.from_yaml()
+                except ValueError:
+                    self.config = Config.from_env()
 
-        self.token = None
-        self.token_expiry = None
-        self._http_client = self._authenticate_and_initialize_client()
+            self._owns_session = True
+            self.token = None
+            self.token_expiry = None
+            self._http_client = self._authenticate_and_initialize_client()
 
     def _authenticate_and_initialize_client(self) -> requests.Session:
         """Authenticate and initialize the HTTP client with a valid token."""
@@ -68,8 +83,10 @@ class DatacosmosClient:
             ) from e
 
     def _refresh_token_if_needed(self):
-        """Refresh the token if it has expired."""
-        if not self.token or self.token_expiry <= datetime.now(timezone.utc):
+        """Refresh the token if it has expired (only if SDK created it)."""
+        if self._owns_session and (
+            not self.token or self.token_expiry <= datetime.now(timezone.utc)
+        ):
             self._http_client = self._authenticate_and_initialize_client()
 
     def request(

--- a/datacosmos/uploader/datacosmos_uploader.py
+++ b/datacosmos/uploader/datacosmos_uploader.py
@@ -17,14 +17,10 @@ class DatacosmosUploader:
 
     def __init__(self, client: DatacosmosClient):
         """Initialize the uploader with DatacosmosClient."""
-        mission_id = client.config.mission_id
-        environment = client.config.environment
+        self.environment = client.config.environment
 
         self.datacosmos_client = client
         self.item_client = ItemClient(client)
-        self.mission_name = (
-            get_mission_name(mission_id, environment) if mission_id != 0 else ""
-        )
         self.base_url = client.config.datacosmos_cloud_storage.as_domain_url()
 
     def upload_and_register_item(self, item_json_file_path: str) -> None:
@@ -92,9 +88,12 @@ class DatacosmosUploader:
         except Exception:  # nosec
             pass  # Ignore if item doesn't exist
 
-    def _get_upload_path(self, item: DatacosmosItem) -> str:
+    def _get_upload_path(self, item: DatacosmosItem, mission_id: int = 0) -> str:
         """Constructs the storage upload path based on the item and mission name."""
-        return UploadPath.from_item_path(item, self.mission_name, "")
+        mission_name = (
+            get_mission_name(mission_id, self.environment) if mission_id != 0 else ""
+        )
+        return UploadPath.from_item_path(item, mission_name, "")
 
     def _update_item_assets(self, item: DatacosmosItem) -> None:
         """Updates the item's assets with uploaded file URLs."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datacosmos"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
     { name="Open Cosmos", email="support@open-cosmos.com" },
 ]

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -35,8 +35,6 @@ class TestConfig:
         assert config.stac.port == 443
         assert config.stac.path == "/api/data/v0/stac"
 
-        assert config.mission_id == 0
-
     def test_from_yaml_ignores_missing_file(self):
         # If file doesn't exist, returns default config with required fields missing, so should raise error
         with pytest.raises(ValueError):

--- a/tests/unit/datacosmos/uploader/test_datacosmos_uploader.py
+++ b/tests/unit/datacosmos/uploader/test_datacosmos_uploader.py
@@ -21,16 +21,11 @@ class TestDatacosmosUploader:
         return mock
 
     def test_init_sets_attributes(self, mock_client):
-        with patch(
-            "datacosmos.uploader.datacosmos_uploader.get_mission_name"
-        ) as mock_get_mission_name:
-            mock_get_mission_name.return_value = "mockmission"
-            uploader = DatacosmosUploader(mock_client)
+        uploader = DatacosmosUploader(mock_client)
 
-            assert uploader.datacosmos_client == mock_client
-            assert uploader.item_client is not None
-            assert uploader.mission_name == "mockmission"
-            assert uploader.base_url.startswith("https://mockstorage.com/")
+        assert uploader.datacosmos_client == mock_client
+        assert uploader.item_client is not None
+        assert uploader.base_url.startswith("https://mockstorage.com/")
 
     @patch("datacosmos.datacosmos_client.DatacosmosClient.put")
     @patch(


### PR DESCRIPTION
This MR allows the SDK to use an existent http session instead of always creating a new one.