### PR TITLE
Add project item operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ client = DatacosmosClient(config=config)
 | `datacosmos_public_cloud_storage.host`     | `app.open-cosmos.com`                   | YAML / ENV     |
 | `datacosmos_public_cloud_storage.port`     | `443`                                   | YAML / ENV     |
 | `datacosmos_public_cloud_storage.path`     | `/api/data/v0/storage`                 | YAML / ENV     |
+| `project.protocol`                         | `https`                                 | YAML / ENV     |
+| `project.host`                             | `app.open-cosmos.com`                   | YAML / ENV     |
+| `project.port`                             | `443`                                   | YAML / ENV     |
+| `project.path`                             | `/api/data/v0/scenario`                 | YAML / ENV     |
 
 ## STAC Client
 
@@ -330,6 +334,157 @@ client = DatacosmosClient()
 stac_client = STACClient(client)
 
 stac_client.delete_collection("test-collection")
+```
+
+### Project Item Operations
+
+The `STACClient` also provides methods to interact with project/scenario items. Projects (also called scenarios) are collections of STAC items that can include both linked catalog items and project-specific items.
+
+#### 11. List Project Items
+
+List all items in a project/scenario:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+items = list(stac_client.list_project_items(scenario_id))
+
+for item in items:
+    print(f"{item.id} (collection: {item.collection_id})")
+```
+
+#### 12. Get a Project Item
+
+Fetch a specific item from a project:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+item_id = "your-item-id"
+
+item = stac_client.get_project_item(scenario_id, item_id)
+print(f"Item: {item.id}")
+```
+
+#### 13. Add an Item to a Project
+
+Link an existing catalog item to a project:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+collection_id = "catalog-collection-id"
+item_id = "catalog-item-id"
+
+stac_client.add_project_item(scenario_id, collection_id, item_id)
+```
+
+#### 14. Create a Project Item
+
+Create a new STAC item directly in a project:
+
+```python
+from pystac import Item
+from datetime import datetime
+
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+
+stac_item = Item(
+    id="new-project-item",
+    geometry={"type": "Point", "coordinates": [102.0, 0.5]},
+    bbox=[101.0, 0.0, 103.0, 1.0],
+    datetime=datetime.utcnow(),
+    properties={"datetime": datetime.utcnow().isoformat()},
+)
+
+stac_client.create_project_item(scenario_id, stac_item)
+```
+
+#### 15. Delete a Project Item
+
+Remove an item from a project:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+item_id = "item-to-delete"
+
+stac_client.delete_project_item(scenario_id, item_id)
+```
+
+#### 16. Search Project Items
+
+Search for items within a project with optional filters:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+from datacosmos.stac.project.models.project_search_parameters import ProjectSearchParameters
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+
+# Search with parameters
+params = ProjectSearchParameters(
+    collections=["specific-collection"],
+    limit=10
+)
+
+results = list(stac_client.search_project_items(scenario_id, params))
+for item in results:
+    print(f"{item.id}")
+```
+
+#### 17. Check if Items Exist in a Project
+
+Check if specific catalog items are linked to a project:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+from datacosmos.stac.project.models.collection_item_pair import CollectionItemPair
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+scenario_id = "your-scenario-uuid"
+
+pairs = [
+    CollectionItemPair(collection="collection-1", item="item-1"),
+    CollectionItemPair(collection="collection-2", item="item-2"),
+]
+
+existence = stac_client.check_project_items_exist(scenario_id, pairs)
+for result in existence:
+    print(f"{result.collection}/{result.item}: exists={result.exists}")
 ```
 
 ## Uploading Files and Registering STAC Items

--- a/README.md
+++ b/README.md
@@ -378,9 +378,12 @@ print(f"Item: {item.id}")
 
 #### 13. Add an Item to a Project
 
-Link an existing catalog item to a project:
+Add or update an item in a project (upsert):
 
 ```python
+from pystac import Item
+from datetime import datetime
+
 from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.stac_client import STACClient
 
@@ -388,10 +391,16 @@ client = DatacosmosClient()
 stac_client = STACClient(client)
 
 scenario_id = "your-scenario-uuid"
-collection_id = "catalog-collection-id"
-item_id = "catalog-item-id"
 
-stac_client.add_project_item(scenario_id, collection_id, item_id)
+item = Item(
+    id="my-item-id",
+    geometry={"type": "Point", "coordinates": [102.0, 0.5]},
+    bbox=[101.0, 0.0, 103.0, 1.0],
+    datetime=datetime.utcnow(),
+    properties={},
+)
+
+stac_client.add_project_item(scenario_id, item)
 ```
 
 #### 14. Create a Project Item

--- a/README.md
+++ b/README.md
@@ -496,6 +496,39 @@ for result in existence:
     print(f"{result.collection}/{result.item}: exists={result.exists}")
 ```
 
+#### 18. Register a Catalog Item to a Project
+
+Link an existing catalog item to a project. This creates a relation between the item and the project without copying the item:
+
+```python
+from pystac import Item
+from datetime import datetime
+
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+project_id = "your-project-uuid"
+
+# First, create/add the item to the catalog
+stac_item = Item(
+    id="catalog-item",
+    geometry={"type": "Point", "coordinates": [102.0, 0.5]},
+    bbox=[101.0, 0.0, 103.0, 1.0],
+    datetime=datetime.utcnow(),
+    properties={"processing:level": "l1a"},
+    collection="my-collection"
+)
+stac_client.add_item(stac_item)
+
+# Then register/link it to a project
+stac_client.register_item_to_project(stac_item, project_id)
+```
+
+This is useful when you want to associate existing catalog items with a project without duplicating the data.
+
 ## Uploading Files and Registering STAC Items
 
 You can use the `STACClient` class to upload files to the DataCosmos cloud storage and register a STAC item.

--- a/datacosmos/config/config.py
+++ b/datacosmos/config/config.py
@@ -13,6 +13,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from datacosmos.config.auth.factory import normalize_authentication, parse_auth_config
 from datacosmos.config.constants import (
     DEFAULT_CONFIG_YAML,
+    DEFAULT_PROJECT,
     DEFAULT_STAC,
     DEFAULT_STORAGE,
 )
@@ -43,6 +44,7 @@ class Config(BaseSettings):
     datacosmos_public_cloud_storage: URL = Field(
         default_factory=lambda: URL(**DEFAULT_STORAGE)
     )
+    project: URL = Field(default_factory=lambda: URL(**DEFAULT_PROJECT))
 
     @classmethod
     def settings_customise_sources(cls, *args, **kwargs):

--- a/datacosmos/config/constants.py
+++ b/datacosmos/config/constants.py
@@ -21,6 +21,9 @@ DEFAULT_STAC = dict(
 DEFAULT_STORAGE = dict(
     protocol="https", host="app.open-cosmos.com", port=443, path="/api/data/v0/storage"
 )
+DEFAULT_PROJECT = dict(
+    protocol="https", host="app.open-cosmos.com", port=443, path="/api/data/v0"
+)
 
 # ---- Config file path ----
 DEFAULT_CONFIG_YAML = "config/config.yaml"

--- a/datacosmos/stac/item/item_client.py
+++ b/datacosmos/stac/item/item_client.py
@@ -153,6 +153,51 @@ class ItemClient:
         response = self.client.delete(url)
         check_api_response(response)
 
+    def register_item_to_project(
+        self, item: Item | DatacosmosItem, project_id: str
+    ) -> None:
+        """Register a STAC item to a project.
+
+        This method associates a STAC item with a specific project by creating
+        a relation. The item does not need to exist in the catalog first - it
+        can be registered directly to a project for project-scoped data.
+
+        Args:
+            item (Item | DatacosmosItem): The STAC item to register to the project.
+                Must have both an id and collection set.
+            project_id (str): The ID of the project to register the item to.
+
+        Raises:
+            ValueError: If the item has no id or collection set.
+            DatacosmosError: If the API returns an error response.
+
+        Example:
+            # Option 1: Register to project only (project-scoped data)
+            item_client.register_item_to_project(item, project_id="my-project-id")
+
+            # Option 2: Register to both catalog and project
+            item_client.create_item(item)  # catalog
+            item_client.register_item_to_project(item, project_id="my-project-id")
+        """
+        collection_id = self._get_collection_id(item, method="register_to_project")
+
+        if not item.id:
+            raise ValueError(
+                "Cannot register item to project: no item_id found on item"
+            )
+
+        # Build URL: /api/data/v0/scenario/relation
+        scenario_relation_url = self.client.config.project.as_domain_url().with_suffix(
+            "/relation"
+        )
+        body = {
+            "scenario": project_id,
+            "collection": collection_id,
+            "item": item.id,
+        }
+        response = self.client.post(scenario_relation_url, json=body)
+        check_api_response(response)
+
     def _paginate_items(self, url: str, body: dict) -> Generator[Item, None, None]:
         """Handle pagination for the STAC search POST endpoint.
 

--- a/datacosmos/stac/project/__init__.py
+++ b/datacosmos/stac/project/__init__.py
@@ -1,0 +1,4 @@
+"""Project module for interacting with project/scenario items from the Project Service API.
+
+Provides operations to get, add, search, and list items within projects (scenarios).
+"""

--- a/datacosmos/stac/project/models/__init__.py
+++ b/datacosmos/stac/project/models/__init__.py
@@ -1,0 +1,13 @@
+"""Models for project item operations."""
+
+from datacosmos.stac.project.models.collection_item_pair import CollectionItemPair
+from datacosmos.stac.project.models.project_search_parameters import (
+    ProjectSearchParameters,
+)
+from datacosmos.stac.project.models.relation_existence import RelationExistence
+
+__all__ = [
+    "CollectionItemPair",
+    "ProjectSearchParameters",
+    "RelationExistence",
+]

--- a/datacosmos/stac/project/models/collection_item_pair.py
+++ b/datacosmos/stac/project/models/collection_item_pair.py
@@ -1,0 +1,10 @@
+"""Model for collection/item pair used in project contains check."""
+
+from pydantic import BaseModel, Field
+
+
+class CollectionItemPair(BaseModel):
+    """A pair of collection ID and item ID for checking existence in a project."""
+
+    collection: str = Field(..., description="Collection ID of the catalog item")
+    item: str = Field(..., description="Item ID within the collection")

--- a/datacosmos/stac/project/models/project_search_parameters.py
+++ b/datacosmos/stac/project/models/project_search_parameters.py
@@ -1,0 +1,64 @@
+"""Query parameters for project item search."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ProjectSearchParameters(BaseModel):
+    """Query parameters for searching items within a project/scenario.
+
+    This follows the STAC search parameters structure used by the project service.
+    """
+
+    ids: Optional[List[str]] = Field(
+        None,
+        description="Filter by specific item IDs",
+    )
+    collections: Optional[List[str]] = Field(
+        None,
+        description="Filter by specific collection IDs",
+    )
+    bbox: Optional[List[float]] = Field(
+        None,
+        description="Bounding box filter [west, south, east, north]",
+    )
+    datetime: Optional[str] = Field(
+        None,
+        description="Temporal filter (single datetime or interval)",
+        examples=["2024-01-01T00:00:00Z/2024-12-31T23:59:59Z"],
+    )
+    intersects: Optional[Dict[str, Any]] = Field(
+        None,
+        description="GeoJSON geometry to intersect with",
+    )
+    limit: Optional[int] = Field(
+        None,
+        description="Maximum number of items to return",
+        ge=1,
+    )
+    query: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Property-based query constraints",
+    )
+
+    def to_request_body(self) -> dict:
+        """Convert parameters to request body for the search endpoint."""
+        body = {}
+
+        if self.ids is not None:
+            body["ids"] = self.ids
+        if self.collections is not None:
+            body["collections"] = self.collections
+        if self.bbox is not None:
+            body["bbox"] = self.bbox
+        if self.datetime is not None:
+            body["datetime"] = self.datetime
+        if self.intersects is not None:
+            body["intersects"] = self.intersects
+        if self.limit is not None:
+            body["limit"] = self.limit
+        if self.query is not None:
+            body["query"] = self.query
+
+        return body

--- a/datacosmos/stac/project/models/relation_existence.py
+++ b/datacosmos/stac/project/models/relation_existence.py
@@ -1,0 +1,16 @@
+"""Model for relation existence response from project contains check."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RelationExistence(BaseModel):
+    """Response indicating whether a collection/item pair exists in a project."""
+
+    collection: str = Field(..., description="Collection ID of the catalog item")
+    item: str = Field(..., description="Item ID within the collection")
+    relation: Optional[str] = Field(
+        None, description="Relation ID if the item exists in the project"
+    )
+    exists: bool = Field(..., description="Whether the item exists in the project")

--- a/datacosmos/stac/project/project_item_client.py
+++ b/datacosmos/stac/project/project_item_client.py
@@ -1,0 +1,247 @@
+"""Project Item Client module for interacting with project/scenario items.
+
+Provides methods for listing, fetching, creating, updating, deleting, and searching
+items within projects (scenarios) via the Project Service API.
+"""
+
+from typing import Generator, List, Optional
+from urllib.parse import parse_qs, urlparse
+
+from pystac import Item
+
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.exceptions.datacosmos_error import DatacosmosError
+from datacosmos.stac.item.models.datacosmos_item import DatacosmosItem
+from datacosmos.stac.project.models.collection_item_pair import CollectionItemPair
+from datacosmos.stac.project.models.project_search_parameters import (
+    ProjectSearchParameters,
+)
+from datacosmos.stac.project.models.relation_existence import RelationExistence
+from datacosmos.utils.http_response.check_api_response import check_api_response
+
+
+class ProjectItemClient:
+    """Client for interacting with project/scenario items via the Project Service API."""
+
+    def __init__(self, client: DatacosmosClient):
+        """Initialize the ProjectItemClient with a DatacosmosClient.
+
+        Args:
+            client (DatacosmosClient): The authenticated Datacosmos client instance.
+        """
+        self.client = client
+        self.project_base_url = client.config.project.as_domain_url()
+
+    def list_project_items(
+        self, scenario_id: str
+    ) -> Generator[Item, None, None]:
+        """List all items in a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+
+        Yields:
+            Item: STAC items belonging to the scenario.
+        """
+        url = self.project_base_url.with_suffix(f"/scenario/{scenario_id}/items")
+        response = self.client.get(url)
+        check_api_response(response)
+
+        data = response.json()
+        # Handle OC API response format with 'data' wrapper
+        items_data = data.get("data", data)
+
+        if isinstance(items_data, dict) and "features" in items_data:
+            # Use `or []` to handle both missing key and null value
+            features = items_data.get("features") or []
+        elif isinstance(items_data, list):
+            features = items_data
+        else:
+            features = []
+
+        yield from (Item.from_dict(feature) for feature in features)
+
+    def get_project_item(self, scenario_id: str, item_id: str) -> DatacosmosItem:
+        """Fetch a specific item from a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            item_id (str): The ID of the item to fetch.
+
+        Returns:
+            DatacosmosItem: The fetched STAC item.
+        """
+        url = self.project_base_url.with_suffix(
+            f"/scenario/{scenario_id}/items/{item_id}"
+        )
+        response = self.client.get(url)
+        check_api_response(response)
+
+        data = response.json()
+        # Handle OC API response format with 'data' wrapper
+        item_data = data.get("data", data)
+        return DatacosmosItem.from_dict(item_data)
+
+    def create_project_item(
+        self, scenario_id: str, item: Item | DatacosmosItem
+    ) -> None:
+        """Create a new item in a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            item (Item | DatacosmosItem): The STAC item to create.
+
+        Raises:
+            ValueError: If the item has no ID.
+        """
+        if not item.id:
+            raise ValueError("Cannot create item: no item_id found on item")
+
+        url = self.project_base_url.with_suffix(f"/scenario/{scenario_id}/items")
+        item_json: dict = item.to_dict()
+        response = self.client.post(url, json=item_json)
+        check_api_response(response)
+
+    def add_project_item(
+        self, scenario_id: str, item: Item | DatacosmosItem
+    ) -> None:
+        """Add or update an item in a project/scenario (upsert).
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            item (Item | DatacosmosItem): The STAC item to add or update.
+
+        Raises:
+            ValueError: If the item has no ID.
+        """
+        if not item.id:
+            raise ValueError("Cannot add item: no item_id found on item")
+
+        url = self.project_base_url.with_suffix(
+            f"/scenario/{scenario_id}/items/{item.id}"
+        )
+        item_json: dict = item.to_dict()
+        response = self.client.put(url, json=item_json)
+        check_api_response(response)
+
+    def delete_project_item(self, scenario_id: str, item_id: str) -> None:
+        """Delete an item from a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            item_id (str): The ID of the item to delete.
+        """
+        url = self.project_base_url.with_suffix(
+            f"/scenario/{scenario_id}/items/{item_id}"
+        )
+        response = self.client.delete(url)
+        check_api_response(response)
+
+    def search_project_items(
+        self,
+        scenario_id: str,
+        parameters: Optional[ProjectSearchParameters] = None,
+    ) -> Generator[Item, None, None]:
+        """Search for items within a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            parameters (ProjectSearchParameters, optional): Search parameters.
+
+        Yields:
+            Item: Matching STAC items.
+        """
+        url = self.project_base_url.with_suffix(f"/scenario/{scenario_id}/search")
+        body = parameters.to_request_body() if parameters else {}
+
+        return self._paginate_project_items(url, body)
+
+    def check_project_items_exist(
+        self, scenario_id: str, items: List[CollectionItemPair]
+    ) -> List[RelationExistence]:
+        """Check if catalog items exist in a project/scenario.
+
+        Args:
+            scenario_id (str): The ID of the scenario/project.
+            items (List[CollectionItemPair]): List of collection/item pairs to check.
+
+        Returns:
+            List[RelationExistence]: Existence status for each pair.
+        """
+        url = self.project_base_url.with_suffix(f"/scenario/{scenario_id}/contains")
+        body = [item.model_dump() for item in items]
+        response = self.client.post(url, json=body)
+        check_api_response(response)
+
+        data = response.json()
+        # Handle both direct list response and OC API wrapper
+        results = data if isinstance(data, list) else data.get("data", [])
+
+        return [RelationExistence.model_validate(result) for result in results]
+
+    def _paginate_project_items(
+        self, url: str, body: dict
+    ) -> Generator[Item, None, None]:
+        """Handle pagination for the project search endpoint.
+
+        Args:
+            url: The project search endpoint URL.
+            body: The request body containing search parameters.
+
+        Yields:
+            Item: Parsed STAC items from the search results.
+        """
+        request_body = body.copy()
+
+        while True:
+            response = self.client.post(url, json=request_body)
+            check_api_response(response)
+            data = response.json()
+
+            # Use `or []` to handle both missing key and null value
+            features = data.get("features") or []
+            yield from (Item.from_dict(feature) for feature in features)
+
+            next_href = self._get_next_link(data)
+            if not next_href:
+                break
+
+            token = self._extract_pagination_token(next_href)
+            if not token:
+                break
+
+            request_body["cursor"] = token
+
+    def _get_next_link(self, data: dict) -> Optional[str]:
+        """Extract the next page link from the response.
+
+        Args:
+            data: The JSON response data from the search endpoint.
+
+        Returns:
+            The href of the next page link, or None if not found.
+        """
+        next_link = next(
+            (link for link in data.get("links", []) if link.get("rel") == "next"), None
+        )
+        return next_link.get("href", "") if next_link else None
+
+    def _extract_pagination_token(self, next_href: str) -> Optional[str]:
+        """Extract the pagination token (cursor) from the next link URL.
+
+        Args:
+            next_href: The URL of the next page from the response.
+
+        Returns:
+            The cursor token for the next page, or None if not found.
+        """
+        try:
+            parsed = urlparse(next_href)
+            query_params = parse_qs(parsed.query)
+            cursor_values = query_params.get("cursor", [])
+            return cursor_values[0] if cursor_values else None
+        except (ValueError, TypeError) as e:
+            raise DatacosmosError(
+                f"Failed to parse pagination cursor from next link: {next_href}. "
+                f"Expected URL with 'cursor' query parameter. Error: {e}"
+            ) from e

--- a/datacosmos/stac/stac_client.py
+++ b/datacosmos/stac/stac_client.py
@@ -3,10 +3,11 @@
 from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.collection.collection_client import CollectionClient
 from datacosmos.stac.item.item_client import ItemClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
 from datacosmos.stac.storage.storage_client import StorageClient
 
 
-class STACClient(ItemClient, CollectionClient, StorageClient):
+class STACClient(ItemClient, CollectionClient, StorageClient, ProjectItemClient):
     """Unified interface for STAC API, combining Item & Collection operations."""
 
     def __init__(self, client: DatacosmosClient):
@@ -14,3 +15,4 @@ class STACClient(ItemClient, CollectionClient, StorageClient):
         ItemClient.__init__(self, client)
         CollectionClient.__init__(self, client)
         StorageClient.__init__(self, client)
+        ProjectItemClient.__init__(self, client)

--- a/tests/unit/datacosmos/stac/item/item_client/test_register_item_to_project.py
+++ b/tests/unit/datacosmos/stac/item/item_client/test_register_item_to_project.py
@@ -1,0 +1,140 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pystac import Item
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.item.item_client import ItemClient
+from datacosmos.stac.item.models.datacosmos_item import DatacosmosItem
+
+
+class TestItemClientRegisterItemToProject(unittest.TestCase):
+    """Unit tests for the ItemClient.register_item_to_project method."""
+
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_post = patch.object(DatacosmosClient, "post").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.item.item_client.check_api_response"
+        ).start()
+
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
+        )
+        self.client = DatacosmosClient(config=self.config)
+        self.item_client = ItemClient(self.client)
+
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
+
+    def test_register_pystac_item_to_project(self):
+        """Test registering a pystac Item to a project."""
+        self.mock_post.return_value = MagicMock(status_code=200)
+
+        item = Item.from_dict({
+            "id": "item-1",
+            "collection": "test-collection",
+            "type": "Feature",
+            "stac_version": "1.1.0",
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "properties": {"datetime": "2023-12-01T12:00:00Z"},
+            "assets": {},
+            "links": [],
+        })
+
+        self.item_client.register_item_to_project(item, "project-123")
+
+        self.mock_post.assert_called_once()
+        call_args = self.mock_post.call_args
+        # Verify the URL ends with /relation
+        url = str(call_args[0][0])
+        assert "/scenario/relation" in url or url.endswith("/relation")
+        # Verify the body
+        body = call_args[1]["json"]
+        assert body["scenario"] == "project-123"
+        assert body["collection"] == "test-collection"
+        assert body["item"] == "item-1"
+
+    def test_register_datacosmos_item_to_project(self):
+        """Test registering a DatacosmosItem to a project."""
+        self.mock_post.return_value = MagicMock(status_code=200)
+
+        item = DatacosmosItem(
+            id="item-2",
+            type="Feature",
+            stac_version="1.0.0",
+            stac_extensions=[],
+            geometry={"type": "Point", "coordinates": [0, 0]},
+            bbox=[0, 0, 1, 1],
+            properties={"datetime": "2023-12-01T12:00:00Z"},
+            links=[],
+            assets={},
+            collection="my-collection",
+        )
+
+        self.item_client.register_item_to_project(item, "project-456")
+
+        self.mock_post.assert_called_once()
+        call_args = self.mock_post.call_args
+        body = call_args[1]["json"]
+        assert body["scenario"] == "project-456"
+        assert body["collection"] == "my-collection"
+        assert body["item"] == "item-2"
+
+    def test_register_item_without_collection_raises(self):
+        """Test that registering an item without a collection raises ValueError."""
+        item = Item.from_dict({
+            "id": "item-no-collection",
+            "type": "Feature",
+            "stac_version": "1.1.0",
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "properties": {"datetime": "2023-12-01T12:00:00Z"},
+            "assets": {},
+            "links": [],
+        })
+
+        with self.assertRaises(ValueError) as ctx:
+            self.item_client.register_item_to_project(item, "project-123")
+
+        assert "no collection_id found" in str(ctx.exception)
+
+    def test_register_item_without_id_raises(self):
+        """Test that registering an item without an id raises ValueError."""
+        from datetime import datetime as dt
+
+        # Create valid item then clear the id
+        item = Item(
+            id="temp-id",
+            geometry={"type": "Point", "coordinates": [0, 0]},
+            bbox=[0, 0, 1, 1],
+            datetime=dt.utcnow(),
+            properties={},
+        )
+        item.collection_id = "my-collection"
+        item.id = None  # Clear the id after creation
+
+        with self.assertRaises(ValueError) as ctx:
+            self.item_client.register_item_to_project(item, "project-123")
+
+        assert "no item_id found" in str(ctx.exception)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_add_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_add_project_item.py
@@ -1,9 +1,9 @@
 """Tests for ProjectItemClient.add_project_item method."""
 
+import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pystac import Item
 
 from datacosmos.config.config import Config
@@ -12,85 +12,88 @@ from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "put")
-def test_add_project_item(mock_put, mock_check_api_response, mock_fetch_token):
-    """Test adding/upserting an item in a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestAddProjectItem(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.add_project_item method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_put.return_value = mock_response
-    mock_check_api_response.return_value = None
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_put = patch.object(DatacosmosClient, "put").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    item = Item(
-        id="item-456",
-        geometry={
-            "type": "Polygon",
-            "coordinates": [
-                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-            ],
-        },
-        bbox=[0.0, 0.0, 1.0, 1.0],
-        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
-        properties={},
-    )
+    def test_add_project_item(self):
+        """Test adding/upserting an item in a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        self.mock_put.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    project_client.add_project_item("scenario-123", item)
-
-    mock_put.assert_called_once_with(
-        project_client.project_base_url.with_suffix(
-            "/scenario/scenario-123/items/item-456"
-        ),
-        json=item.to_dict(),
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
-
-
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-def test_add_project_item_no_id(mock_fetch_token):
-    """Test adding an item without ID raises ValueError."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
-
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        item = Item(
+            id="item-456",
+            geometry={
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                ],
+            },
+            bbox=[0.0, 0.0, 1.0, 1.0],
+            datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+            properties={},
         )
-    )
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+        self.project_client.add_project_item("scenario-123", item)
 
-    item = Item(
-        id="",
-        geometry={
-            "type": "Polygon",
-            "coordinates": [
-                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-            ],
-        },
-        bbox=[0.0, 0.0, 1.0, 1.0],
-        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
-        properties={},
-    )
+        self.mock_put.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix(
+                "/scenario/scenario-123/items/item-456"
+            ),
+            json=item.to_dict(),
+        )
+        self.mock_check_api_response.assert_called_once_with(mock_response)
 
-    with pytest.raises(ValueError, match="no item_id found on item"):
-        project_client.add_project_item("scenario-123", item)
+    def test_add_project_item_no_id(self):
+        """Test adding an item without ID raises ValueError."""
+        item = Item(
+            id="",
+            geometry={
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                ],
+            },
+            bbox=[0.0, 0.0, 1.0, 1.0],
+            datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+            properties={},
+        )
+
+        with self.assertRaises(ValueError, msg="no item_id found on item"):
+            self.project_client.add_project_item("scenario-123", item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_add_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_add_project_item.py
@@ -1,0 +1,91 @@
+"""Tests for ProjectItemClient.add_project_item method."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pystac import Item
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "put")
+def test_add_project_item(mock_put, mock_check_api_response, mock_fetch_token):
+    """Test adding/upserting an item in a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_put.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    item = Item(
+        id="item-456",
+        geometry={
+            "type": "Polygon",
+            "coordinates": [
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+            ],
+        },
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+        properties={},
+    )
+
+    project_client.add_project_item("scenario-123", item)
+
+    mock_put.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+def test_add_project_item_no_id(mock_fetch_token):
+    """Test adding an item without ID raises ValueError."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    item = Item(
+        id=None,
+        geometry={
+            "type": "Polygon",
+            "coordinates": [
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+            ],
+        },
+        bbox=[0.0, 0.0, 1.0, 1.0],
+        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+        properties={},
+    )
+
+    with pytest.raises(ValueError, match="no item_id found on item"):
+        project_client.add_project_item("scenario-123", item)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_check_project_items_exist.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_check_project_items_exist.py
@@ -1,0 +1,69 @@
+"""Tests for ProjectItemClient.check_project_items_exist method."""
+
+from unittest.mock import MagicMock, patch
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+from datacosmos.stac.project.models.collection_item_pair import CollectionItemPair
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "post")
+def test_check_project_items_exist(
+    mock_post, mock_check_api_response, mock_fetch_token
+):
+    """Test checking if items exist in a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [
+        {
+            "collection": "collection-1",
+            "item": "item-1",
+            "relation": "rel-123",
+            "exists": True,
+        },
+        {
+            "collection": "collection-2",
+            "item": "item-2",
+            "relation": None,
+            "exists": False,
+        },
+    ]
+    mock_post.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    items = [
+        CollectionItemPair(collection="collection-1", item="item-1"),
+        CollectionItemPair(collection="collection-2", item="item-2"),
+    ]
+    results = project_client.check_project_items_exist("scenario-123", items)
+
+    assert len(results) == 2
+    assert results[0].collection == "collection-1"
+    assert results[0].item == "item-1"
+    assert results[0].exists is True
+    assert results[0].relation == "rel-123"
+    assert results[1].collection == "collection-2"
+    assert results[1].item == "item-2"
+    assert results[1].exists is False
+    assert results[1].relation is None
+    mock_post.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_check_project_items_exist.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_check_project_items_exist.py
@@ -1,5 +1,6 @@
 """Tests for ProjectItemClient.check_project_items_exist method."""
 
+import unittest
 from unittest.mock import MagicMock, patch
 
 from datacosmos.config.config import Config
@@ -9,61 +10,79 @@ from datacosmos.stac.project.project_item_client import ProjectItemClient
 from datacosmos.stac.project.models.collection_item_pair import CollectionItemPair
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "post")
-def test_check_project_items_exist(
-    mock_post, mock_check_api_response, mock_fetch_token
-):
-    """Test checking if items exist in a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestCheckProjectItemsExist(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.check_project_items_exist method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = [
-        {
-            "collection": "collection-1",
-            "item": "item-1",
-            "relation": "rel-123",
-            "exists": True,
-        },
-        {
-            "collection": "collection-2",
-            "item": "item-2",
-            "relation": None,
-            "exists": False,
-        },
-    ]
-    mock_post.return_value = mock_response
-    mock_check_api_response.return_value = None
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_post = patch.object(DatacosmosClient, "post").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    items = [
-        CollectionItemPair(collection="collection-1", item="item-1"),
-        CollectionItemPair(collection="collection-2", item="item-2"),
-    ]
-    results = project_client.check_project_items_exist("scenario-123", items)
+    def test_check_project_items_exist(self):
+        """Test checking if items exist in a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "collection": "collection-1",
+                "item": "item-1",
+                "relation": "rel-123",
+                "exists": True,
+            },
+            {
+                "collection": "collection-2",
+                "item": "item-2",
+                "relation": None,
+                "exists": False,
+            },
+        ]
+        self.mock_post.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    assert len(results) == 2
-    assert results[0].collection == "collection-1"
-    assert results[0].item == "item-1"
-    assert results[0].exists is True
-    assert results[0].relation == "rel-123"
-    assert results[1].collection == "collection-2"
-    assert results[1].item == "item-2"
-    assert results[1].exists is False
-    assert results[1].relation is None
-    mock_post.assert_called_once()
-    mock_check_api_response.assert_called_once_with(mock_response)
+        items = [
+            CollectionItemPair(collection="collection-1", item="item-1"),
+            CollectionItemPair(collection="collection-2", item="item-2"),
+        ]
+        results = self.project_client.check_project_items_exist("scenario-123", items)
+
+        assert len(results) == 2
+        assert results[0].collection == "collection-1"
+        assert results[0].item == "item-1"
+        assert results[0].exists is True
+        assert results[0].relation == "rel-123"
+        assert results[1].collection == "collection-2"
+        assert results[1].item == "item-2"
+        assert results[1].exists is False
+        assert results[1].relation is None
+        self.mock_post.assert_called_once()
+        self.mock_check_api_response.assert_called_once_with(mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_create_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_create_project_item.py
@@ -1,4 +1,4 @@
-"""Tests for ProjectItemClient.add_project_item method."""
+"""Tests for ProjectItemClient.create_project_item method."""
 
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -14,14 +14,14 @@ from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 @patch("requests_oauthlib.OAuth2Session.fetch_token")
 @patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "put")
-def test_add_project_item(mock_put, mock_check_api_response, mock_fetch_token):
-    """Test adding/upserting an item in a project/scenario."""
+@patch.object(DatacosmosClient, "post")
+def test_create_project_item(mock_post, mock_check_api_response, mock_fetch_token):
+    """Test creating a new item in a project/scenario."""
     mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
 
     mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_put.return_value = mock_response
+    mock_response.status_code = 201
+    mock_post.return_value = mock_response
     mock_check_api_response.return_value = None
 
     config = Config(
@@ -38,7 +38,7 @@ def test_add_project_item(mock_put, mock_check_api_response, mock_fetch_token):
     project_client = ProjectItemClient(client)
 
     item = Item(
-        id="item-456",
+        id="new-item-789",
         geometry={
             "type": "Polygon",
             "coordinates": [
@@ -50,20 +50,18 @@ def test_add_project_item(mock_put, mock_check_api_response, mock_fetch_token):
         properties={},
     )
 
-    project_client.add_project_item("scenario-123", item)
+    project_client.create_project_item("scenario-123", item)
 
-    mock_put.assert_called_once_with(
-        project_client.project_base_url.with_suffix(
-            "/scenario/scenario-123/items/item-456"
-        ),
+    mock_post.assert_called_once_with(
+        project_client.project_base_url.with_suffix("/scenario/scenario-123/items"),
         json=item.to_dict(),
     )
     mock_check_api_response.assert_called_once_with(mock_response)
 
 
 @patch("requests_oauthlib.OAuth2Session.fetch_token")
-def test_add_project_item_no_id(mock_fetch_token):
-    """Test adding an item without ID raises ValueError."""
+def test_create_project_item_no_id(mock_fetch_token):
+    """Test creating an item without ID raises ValueError."""
     mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
 
     config = Config(
@@ -93,4 +91,4 @@ def test_add_project_item_no_id(mock_fetch_token):
     )
 
     with pytest.raises(ValueError, match="no item_id found on item"):
-        project_client.add_project_item("scenario-123", item)
+        project_client.create_project_item("scenario-123", item)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_create_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_create_project_item.py
@@ -1,9 +1,9 @@
 """Tests for ProjectItemClient.create_project_item method."""
 
+import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pystac import Item
 
 from datacosmos.config.config import Config
@@ -12,83 +12,86 @@ from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "post")
-def test_create_project_item(mock_post, mock_check_api_response, mock_fetch_token):
-    """Test creating a new item in a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestCreateProjectItem(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.create_project_item method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 201
-    mock_post.return_value = mock_response
-    mock_check_api_response.return_value = None
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_post = patch.object(DatacosmosClient, "post").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    item = Item(
-        id="new-item-789",
-        geometry={
-            "type": "Polygon",
-            "coordinates": [
-                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-            ],
-        },
-        bbox=[0.0, 0.0, 1.0, 1.0],
-        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
-        properties={},
-    )
+    def test_create_project_item(self):
+        """Test creating a new item in a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        self.mock_post.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    project_client.create_project_item("scenario-123", item)
-
-    mock_post.assert_called_once_with(
-        project_client.project_base_url.with_suffix("/scenario/scenario-123/items"),
-        json=item.to_dict(),
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
-
-
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-def test_create_project_item_no_id(mock_fetch_token):
-    """Test creating an item without ID raises ValueError."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
-
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        item = Item(
+            id="new-item-789",
+            geometry={
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                ],
+            },
+            bbox=[0.0, 0.0, 1.0, 1.0],
+            datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+            properties={},
         )
-    )
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+        self.project_client.create_project_item("scenario-123", item)
 
-    item = Item(
-        id="",
-        geometry={
-            "type": "Polygon",
-            "coordinates": [
-                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-            ],
-        },
-        bbox=[0.0, 0.0, 1.0, 1.0],
-        datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
-        properties={},
-    )
+        self.mock_post.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix("/scenario/scenario-123/items"),
+            json=item.to_dict(),
+        )
+        self.mock_check_api_response.assert_called_once_with(mock_response)
 
-    with pytest.raises(ValueError, match="no item_id found on item"):
-        project_client.create_project_item("scenario-123", item)
+    def test_create_project_item_no_id(self):
+        """Test creating an item without ID raises ValueError."""
+        item = Item(
+            id="",
+            geometry={
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                ],
+            },
+            bbox=[0.0, 0.0, 1.0, 1.0],
+            datetime=datetime(2023, 1, 1, 10, 30, 9, tzinfo=timezone.utc),
+            properties={},
+        )
+
+        with self.assertRaises(ValueError, msg="no item_id found on item"):
+            self.project_client.create_project_item("scenario-123", item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
@@ -1,0 +1,39 @@
+"""Tests for ProjectItemClient.delete_project_item method."""
+
+from unittest.mock import MagicMock, patch
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "delete")
+def test_delete_project_item(mock_delete, mock_check_api_response, mock_fetch_token):
+    """Test deleting an item from a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_delete.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    project_client.delete_project_item("scenario-123", "item-456")
+
+    mock_delete.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
@@ -35,5 +35,9 @@ def test_delete_project_item(mock_delete, mock_check_api_response, mock_fetch_to
 
     project_client.delete_project_item("scenario-123", "item-456")
 
-    mock_delete.assert_called_once()
+    mock_delete.assert_called_once_with(
+        project_client.project_base_url.with_suffix(
+            "/scenario/scenario-123/items/item-456"
+        )
+    )
     mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_delete_project_item.py
@@ -1,5 +1,6 @@
 """Tests for ProjectItemClient.delete_project_item method."""
 
+import unittest
 from unittest.mock import MagicMock, patch
 
 from datacosmos.config.config import Config
@@ -8,36 +9,56 @@ from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "delete")
-def test_delete_project_item(mock_delete, mock_check_api_response, mock_fetch_token):
-    """Test deleting an item from a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestDeleteProjectItem(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.delete_project_item method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_delete.return_value = mock_response
-    mock_check_api_response.return_value = None
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_delete = patch.object(DatacosmosClient, "delete").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    project_client.delete_project_item("scenario-123", "item-456")
+    def test_delete_project_item(self):
+        """Test deleting an item from a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        self.mock_delete.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    mock_delete.assert_called_once_with(
-        project_client.project_base_url.with_suffix(
-            "/scenario/scenario-123/items/item-456"
+        self.project_client.delete_project_item("scenario-123", "item-456")
+
+        self.mock_delete.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix(
+                "/scenario/scenario-123/items/item-456"
+            )
         )
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
+        self.mock_check_api_response.assert_called_once_with(mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
@@ -1,0 +1,73 @@
+"""Tests for ProjectItemClient.get_project_item method."""
+
+from unittest.mock import MagicMock, patch
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "get")
+def test_get_project_item(mock_get, mock_check_api_response, mock_fetch_token):
+    """Test fetching a specific item from a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "id": "item-123",
+            "type": "Feature",
+            "stac_version": "1.1.0",
+            "stac_extensions": [],
+            "collection": "test-collection",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                ],
+            },
+            "bbox": [0.0, 0.0, 1.0, 1.0],
+            "properties": {"datetime": "2023-01-01T10:30:09Z"},
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "https://example.com/stac/items/item-123.json",
+                    "type": "application/json",
+                },
+            ],
+            "assets": {
+                "visual": {
+                    "href": "https://example.com/data/visual.tif",
+                    "type": "image/tiff; application=geotiff",
+                    "title": "Visual Image",
+                    "roles": ["visual", "data"],
+                }
+            },
+        }
+    }
+    mock_get.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    item = project_client.get_project_item("scenario-123", "item-123")
+
+    assert item.id == "item-123"
+    assert item.properties["datetime"] == "2023-01-01T10:30:09Z"
+    mock_get.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
@@ -69,5 +69,9 @@ def test_get_project_item(mock_get, mock_check_api_response, mock_fetch_token):
 
     assert item.id == "item-123"
     assert item.properties["datetime"] == "2023-01-01T10:30:09Z"
-    mock_get.assert_called_once()
+    mock_get.assert_called_once_with(
+        project_client.project_base_url.with_suffix(
+            "/scenario/scenario-123/items/item-123"
+        )
+    )
     mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_get_project_item.py
@@ -1,5 +1,6 @@
 """Tests for ProjectItemClient.get_project_item method."""
 
+import unittest
 from unittest.mock import MagicMock, patch
 
 from datacosmos.config.config import Config
@@ -8,70 +9,90 @@ from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "get")
-def test_get_project_item(mock_get, mock_check_api_response, mock_fetch_token):
-    """Test fetching a specific item from a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestGetProjectItem(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.get_project_item method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": {
-            "id": "item-123",
-            "type": "Feature",
-            "stac_version": "1.1.0",
-            "stac_extensions": [],
-            "collection": "test-collection",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-                ],
-            },
-            "bbox": [0.0, 0.0, 1.0, 1.0],
-            "properties": {"datetime": "2023-01-01T10:30:09Z"},
-            "links": [
-                {
-                    "rel": "self",
-                    "href": "https://example.com/stac/items/item-123.json",
-                    "type": "application/json",
-                },
-            ],
-            "assets": {
-                "visual": {
-                    "href": "https://example.com/data/visual.tif",
-                    "type": "image/tiff; application=geotiff",
-                    "title": "Visual Image",
-                    "roles": ["visual", "data"],
-                }
-            },
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_get = patch.object(DatacosmosClient, "get").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
+
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
         }
-    }
-    mock_get.return_value = mock_response
-    mock_check_api_response.return_value = None
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    item = project_client.get_project_item("scenario-123", "item-123")
+    def test_get_project_item(self):
+        """Test fetching a specific item from a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "id": "item-123",
+                "type": "Feature",
+                "stac_version": "1.1.0",
+                "stac_extensions": [],
+                "collection": "test-collection",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                    ],
+                },
+                "bbox": [0.0, 0.0, 1.0, 1.0],
+                "properties": {"datetime": "2023-01-01T10:30:09Z"},
+                "links": [
+                    {
+                        "rel": "self",
+                        "href": "https://example.com/stac/items/item-123.json",
+                        "type": "application/json",
+                    },
+                ],
+                "assets": {
+                    "visual": {
+                        "href": "https://example.com/data/visual.tif",
+                        "type": "image/tiff; application=geotiff",
+                        "title": "Visual Image",
+                        "roles": ["visual", "data"],
+                    }
+                },
+            }
+        }
+        self.mock_get.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    assert item.id == "item-123"
-    assert item.properties["datetime"] == "2023-01-01T10:30:09Z"
-    mock_get.assert_called_once_with(
-        project_client.project_base_url.with_suffix(
-            "/scenario/scenario-123/items/item-123"
+        item = self.project_client.get_project_item("scenario-123", "item-123")
+
+        assert item.id == "item-123"
+        assert item.properties["datetime"] == "2023-01-01T10:30:09Z"
+        self.mock_get.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix(
+                "/scenario/scenario-123/items/item-123"
+            )
         )
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
+        self.mock_check_api_response.assert_called_once_with(mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
@@ -1,5 +1,6 @@
 """Tests for ProjectItemClient.list_project_items method."""
 
+import unittest
 from unittest.mock import MagicMock, patch
 
 from datacosmos.config.config import Config
@@ -8,78 +9,98 @@ from datacosmos.datacosmos_client import DatacosmosClient
 from datacosmos.stac.project.project_item_client import ProjectItemClient
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "get")
-def test_list_project_items(mock_get, mock_check_api_response, mock_fetch_token):
-    """Test listing items in a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestListProjectItems(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.list_project_items method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "data": {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "id": "item-1",
-                    "type": "Feature",
-                    "stac_version": "1.1.0",
-                    "stac_extensions": [],
-                    "collection": "test-collection",
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-                        ],
-                    },
-                    "bbox": [0.0, 0.0, 1.0, 1.0],
-                    "properties": {"datetime": "2023-01-01T10:30:09Z"},
-                    "links": [],
-                    "assets": {},
-                },
-                {
-                    "id": "item-2",
-                    "type": "Feature",
-                    "stac_version": "1.1.0",
-                    "stac_extensions": [],
-                    "collection": "test-collection",
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-                        ],
-                    },
-                    "bbox": [0.0, 0.0, 1.0, 1.0],
-                    "properties": {"datetime": "2023-01-02T10:30:09Z"},
-                    "links": [],
-                    "assets": {},
-                },
-            ],
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_get = patch.object(DatacosmosClient, "get").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
+
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
         }
-    }
-    mock_get.return_value = mock_response
-    mock_check_api_response.return_value = None
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
         )
-    )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
 
-    items = list(project_client.list_project_items("scenario-123"))
+    def test_list_project_items(self):
+        """Test listing items in a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "id": "item-1",
+                        "type": "Feature",
+                        "stac_version": "1.1.0",
+                        "stac_extensions": [],
+                        "collection": "test-collection",
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                            ],
+                        },
+                        "bbox": [0.0, 0.0, 1.0, 1.0],
+                        "properties": {"datetime": "2023-01-01T10:30:09Z"},
+                        "links": [],
+                        "assets": {},
+                    },
+                    {
+                        "id": "item-2",
+                        "type": "Feature",
+                        "stac_version": "1.1.0",
+                        "stac_extensions": [],
+                        "collection": "test-collection",
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [
+                                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                            ],
+                        },
+                        "bbox": [0.0, 0.0, 1.0, 1.0],
+                        "properties": {"datetime": "2023-01-02T10:30:09Z"},
+                        "links": [],
+                        "assets": {},
+                    },
+                ],
+            }
+        }
+        self.mock_get.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    assert len(items) == 2
-    assert items[0].id == "item-1"
-    assert items[1].id == "item-2"
-    mock_get.assert_called_once_with(
-        project_client.project_base_url.with_suffix("/scenario/scenario-123/items")
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
+        items = list(self.project_client.list_project_items("scenario-123"))
+
+        assert len(items) == 2
+        assert items[0].id == "item-1"
+        assert items[1].id == "item-2"
+        self.mock_get.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix("/scenario/scenario-123/items")
+        )
+        self.mock_check_api_response.assert_called_once_with(mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
@@ -1,0 +1,83 @@
+"""Tests for ProjectItemClient.list_project_items method."""
+
+from unittest.mock import MagicMock, patch
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "get")
+def test_list_project_items(mock_get, mock_check_api_response, mock_fetch_token):
+    """Test listing items in a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "id": "item-1",
+                    "type": "Feature",
+                    "stac_version": "1.1.0",
+                    "stac_extensions": [],
+                    "collection": "test-collection",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                        ],
+                    },
+                    "bbox": [0.0, 0.0, 1.0, 1.0],
+                    "properties": {"datetime": "2023-01-01T10:30:09Z"},
+                    "links": [],
+                    "assets": {},
+                },
+                {
+                    "id": "item-2",
+                    "type": "Feature",
+                    "stac_version": "1.1.0",
+                    "stac_extensions": [],
+                    "collection": "test-collection",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                        ],
+                    },
+                    "bbox": [0.0, 0.0, 1.0, 1.0],
+                    "properties": {"datetime": "2023-01-02T10:30:09Z"},
+                    "links": [],
+                    "assets": {},
+                },
+            ],
+        }
+    }
+    mock_get.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    items = list(project_client.list_project_items("scenario-123"))
+
+    assert len(items) == 2
+    assert items[0].id == "item-1"
+    assert items[1].id == "item-2"
+    mock_get.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_list_project_items.py
@@ -79,5 +79,7 @@ def test_list_project_items(mock_get, mock_check_api_response, mock_fetch_token)
     assert len(items) == 2
     assert items[0].id == "item-1"
     assert items[1].id == "item-2"
-    mock_get.assert_called_once()
+    mock_get.assert_called_once_with(
+        project_client.project_base_url.with_suffix("/scenario/scenario-123/items")
+    )
     mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
@@ -67,7 +67,10 @@ def test_search_project_items(mock_post, mock_check_api_response, mock_fetch_tok
 
     assert len(items) == 1
     assert items[0].id == "item-1"
-    mock_post.assert_called_once()
+    mock_post.assert_called_once_with(
+        project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
+        json={"collections": ["test-collection"], "limit": 10},
+    )
     mock_check_api_response.assert_called_once_with(mock_response)
 
 
@@ -106,4 +109,8 @@ def test_search_project_items_no_params(
     items = list(project_client.search_project_items("scenario-123"))
 
     assert len(items) == 0
-    mock_post.assert_called_once()
+    mock_post.assert_called_once_with(
+        project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
+        json={},
+    )
+    mock_check_api_response.assert_called_once_with(mock_response)

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
@@ -1,0 +1,109 @@
+"""Tests for ProjectItemClient.search_project_items method."""
+
+from unittest.mock import MagicMock, patch
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.project.project_item_client import ProjectItemClient
+from datacosmos.stac.project.models.project_search_parameters import (
+    ProjectSearchParameters,
+)
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "post")
+def test_search_project_items(mock_post, mock_check_api_response, mock_fetch_token):
+    """Test searching for items in a project/scenario."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "id": "item-1",
+                "type": "Feature",
+                "stac_version": "1.1.0",
+                "stac_extensions": [],
+                "collection": "test-collection",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                    ],
+                },
+                "bbox": [0.0, 0.0, 1.0, 1.0],
+                "properties": {"datetime": "2023-01-01T10:30:09Z"},
+                "links": [],
+                "assets": {},
+            },
+        ],
+        "links": [],
+    }
+    mock_post.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    params = ProjectSearchParameters(
+        collections=["test-collection"],
+        limit=10,
+    )
+    items = list(project_client.search_project_items("scenario-123", params))
+
+    assert len(items) == 1
+    assert items[0].id == "item-1"
+    mock_post.assert_called_once()
+    mock_check_api_response.assert_called_once_with(mock_response)
+
+
+@patch("requests_oauthlib.OAuth2Session.fetch_token")
+@patch("datacosmos.stac.project.project_item_client.check_api_response")
+@patch.object(DatacosmosClient, "post")
+def test_search_project_items_no_params(
+    mock_post, mock_check_api_response, mock_fetch_token
+):
+    """Test searching for items in a project without parameters."""
+    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "type": "FeatureCollection",
+        "features": [],
+        "links": [],
+    }
+    mock_post.return_value = mock_response
+    mock_check_api_response.return_value = None
+
+    config = Config(
+        authentication=M2MAuthenticationConfig(
+            type="m2m",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            token_url="https://mock.token.url/oauth/token",
+            audience="https://mock.audience",
+        )
+    )
+
+    client = DatacosmosClient(config=config)
+    project_client = ProjectItemClient(client)
+
+    items = list(project_client.search_project_items("scenario-123"))
+
+    assert len(items) == 0
+    mock_post.assert_called_once()

--- a/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
+++ b/tests/unit/datacosmos/stac/project/project_item_client/test_search_project_items.py
@@ -1,5 +1,6 @@
 """Tests for ProjectItemClient.search_project_items method."""
 
+import unittest
 from unittest.mock import MagicMock, patch
 
 from datacosmos.config.config import Config
@@ -11,106 +12,105 @@ from datacosmos.stac.project.models.project_search_parameters import (
 )
 
 
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "post")
-def test_search_project_items(mock_post, mock_check_api_response, mock_fetch_token):
-    """Test searching for items in a project/scenario."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
+class TestSearchProjectItems(unittest.TestCase):
+    """Unit tests for the ProjectItemClient.search_project_items method."""
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "id": "item-1",
-                "type": "Feature",
-                "stac_version": "1.1.0",
-                "stac_extensions": [],
-                "collection": "test-collection",
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [
-                        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-                    ],
+    def setUp(self):
+        """Set up mock objects and client instance for all tests."""
+        self.mock_fetch_token = patch(
+            "requests_oauthlib.OAuth2Session.fetch_token"
+        ).start()
+        self.mock_post = patch.object(DatacosmosClient, "post").start()
+        self.mock_check_api_response = patch(
+            "datacosmos.stac.project.project_item_client.check_api_response"
+        ).start()
+
+        self.mock_fetch_token.return_value = {
+            "access_token": "mock-token",
+            "expires_in": 3600,
+        }
+
+        self.config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                token_url="https://mock.token.url/oauth/token",
+                audience="https://mock.audience",
+            )
+        )
+        self.client = DatacosmosClient(config=self.config)
+        self.project_client = ProjectItemClient(self.client)
+
+    def tearDown(self):
+        """Stop all patches."""
+        patch.stopall()
+
+    def test_search_project_items(self):
+        """Test searching for items in a project/scenario."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "id": "item-1",
+                    "type": "Feature",
+                    "stac_version": "1.1.0",
+                    "stac_extensions": [],
+                    "collection": "test-collection",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+                        ],
+                    },
+                    "bbox": [0.0, 0.0, 1.0, 1.0],
+                    "properties": {"datetime": "2023-01-01T10:30:09Z"},
+                    "links": [],
+                    "assets": {},
                 },
-                "bbox": [0.0, 0.0, 1.0, 1.0],
-                "properties": {"datetime": "2023-01-01T10:30:09Z"},
-                "links": [],
-                "assets": {},
-            },
-        ],
-        "links": [],
-    }
-    mock_post.return_value = mock_response
-    mock_check_api_response.return_value = None
+            ],
+            "links": [],
+        }
+        self.mock_post.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        params = ProjectSearchParameters(
+            collections=["test-collection"],
+            limit=10,
         )
-    )
+        items = list(self.project_client.search_project_items("scenario-123", params))
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
-
-    params = ProjectSearchParameters(
-        collections=["test-collection"],
-        limit=10,
-    )
-    items = list(project_client.search_project_items("scenario-123", params))
-
-    assert len(items) == 1
-    assert items[0].id == "item-1"
-    mock_post.assert_called_once_with(
-        project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
-        json={"collections": ["test-collection"], "limit": 10},
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
-
-
-@patch("requests_oauthlib.OAuth2Session.fetch_token")
-@patch("datacosmos.stac.project.project_item_client.check_api_response")
-@patch.object(DatacosmosClient, "post")
-def test_search_project_items_no_params(
-    mock_post, mock_check_api_response, mock_fetch_token
-):
-    """Test searching for items in a project without parameters."""
-    mock_fetch_token.return_value = {"access_token": "mock-token", "expires_in": 3600}
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "type": "FeatureCollection",
-        "features": [],
-        "links": [],
-    }
-    mock_post.return_value = mock_response
-    mock_check_api_response.return_value = None
-
-    config = Config(
-        authentication=M2MAuthenticationConfig(
-            type="m2m",
-            client_id="test-client-id",
-            client_secret="test-client-secret",
-            token_url="https://mock.token.url/oauth/token",
-            audience="https://mock.audience",
+        assert len(items) == 1
+        assert items[0].id == "item-1"
+        self.mock_post.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
+            json={"collections": ["test-collection"], "limit": 10},
         )
-    )
+        self.mock_check_api_response.assert_called_once_with(mock_response)
 
-    client = DatacosmosClient(config=config)
-    project_client = ProjectItemClient(client)
+    def test_search_project_items_no_params(self):
+        """Test searching for items in a project without parameters."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "type": "FeatureCollection",
+            "features": [],
+            "links": [],
+        }
+        self.mock_post.return_value = mock_response
+        self.mock_check_api_response.return_value = None
 
-    items = list(project_client.search_project_items("scenario-123"))
+        items = list(self.project_client.search_project_items("scenario-123"))
 
-    assert len(items) == 0
-    mock_post.assert_called_once_with(
-        project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
-        json={},
-    )
-    mock_check_api_response.assert_called_once_with(mock_response)
+        assert len(items) == 0
+        self.mock_post.assert_called_once_with(
+            self.project_client.project_base_url.with_suffix("/scenario/scenario-123/search"),
+            json={},
+        )
+        self.mock_check_api_response.assert_called_once_with(mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add ProjectItemClient module that allows users to interact with items in projects/scenarios via the Project Service API.


Demo:



https://github.com/user-attachments/assets/2387886c-32a9-4e63-8ab1-650dfad3b92b



