### PR TITLE
Add token parameter support and update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,61 @@ config = Config(
 client = DatacosmosClient(config=config)
 ```
 
+### Using a Pre-obtained Token
+
+If you already have an access token (e.g., from an external authentication flow), you can pass it directly:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+
+client = DatacosmosClient(token="your-access-token")
+```
+
+**Note:** When using a token directly, the client will not attempt to refresh it automatically. You are responsible for managing token expiration.
+
+### Using a Pre-authenticated Session
+
+For advanced use cases where you manage your own HTTP session (e.g., with custom middleware or authentication), you can inject it:
+
+```python
+import requests
+from datacosmos.datacosmos_client import DatacosmosClient
+
+# Create a session with your own authentication setup
+session = requests.Session()
+session.headers.update({"Authorization": "Bearer your-token"})
+
+client = DatacosmosClient(http_session=session)
+```
+
+You can also use an OAuth2Session:
+
+```python
+from requests_oauthlib import OAuth2Session
+from datacosmos.datacosmos_client import DatacosmosClient
+
+oauth_session = OAuth2Session(client_id="your-client-id")
+oauth_session.token = {
+    "access_token": "your-access-token",
+    "expires_in": 3600
+}
+
+client = DatacosmosClient(http_session=oauth_session)
+```
+
+### Local User Authentication (Interactive)
+
+For interactive local development, you can use browser-based authentication:
+
+```yaml
+# config/config.yaml
+authentication:
+    type: local
+    client_id: {client_id}
+```
+
+This opens a browser window for login and caches the token locally at `~/.datacosmos/token_cache.json`.
+
 ### Configuration Options and Defaults
 
 | Setting                      | Default Value                                     | Override Method |
@@ -570,16 +625,134 @@ assets_path = "path/to/assets"
 stac_client.upload_item(stac_item, assets_path)
 ```
 
-## Error Handling
+### Download Assets
 
-Use `try-except` blocks to handle API errors gracefully:
+Download all assets of a STAC item to a local directory:
 
 ```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+# Download assets for an item
+item, successes, failures = stac_client.download_assets(
+    item="item-id",
+    collection_id="collection-id",
+    target_path="./downloads",
+    included_assets=True,  # True for all assets, or list of asset keys
+    overwrite=True,
+    max_workers=4
+)
+
+print(f"Downloaded {len(successes)} assets")
+if failures:
+    print(f"Failed: {failures}")
+```
+
+### Delete Item with Assets
+
+Delete a STAC item and optionally remove its assets from storage:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.stac.stac_client import STACClient
+
+client = DatacosmosClient()
+stac_client = STACClient(client)
+
+# Delete item and all its assets from storage
+result = stac_client.delete_item_with_assets(
+    item_id="item-id",
+    collection_id="collection-id",
+    delete_from_storage=True,  # Set to False to keep files in storage
+    max_workers=4
+)
+
+print(f"Item deleted: {result.item_deleted}")
+print(f"Assets deleted: {result.assets_deleted}")
+print(f"Assets failed: {result.assets_failed}")
+```
+
+### Load and Save Items
+
+Utility methods for working with STAC items as JSON files:
+
+```python
+from datacosmos.stac.storage.uploader import Uploader
+
+# Load an item from a JSON file
+item = Uploader.load_item("./data/my-item.json")
+
+# Save an item to a directory (creates {item.id}.json)
+saved_path = Uploader.save_item(item, "./output")
+print(f"Saved to: {saved_path}")
+```
+
+## Error Handling
+
+The SDK provides specific exception types for different error scenarios:
+
+```python
+from datacosmos.exceptions import (
+    AuthenticationError,
+    DatacosmosError,
+    HTTPError,
+    ItemNotFoundError,
+    CollectionError,
+    DeleteError,
+    StorageError,
+    UploadError,
+    StacValidationError,
+)
+
 try:
-    data = client.get_data("dataset_id")
-    print(data)
-except Exception as e:
-    print(f"An error occurred: {e}")
+    item = stac_client.fetch_item(item_id="missing", collection_id="col")
+except ItemNotFoundError:
+    print("Item does not exist")
+except AuthenticationError:
+    print("Authentication failed - check your credentials")
+except HTTPError as e:
+    print(f"HTTP error: {e.status_code} - {e.message}")
+except DatacosmosError as e:
+    print(f"General API error: {e}")
+```
+
+### Exception Types
+
+| Exception | When Raised |
+|-----------|-----------|
+| `AuthenticationError` | Authentication fails (invalid credentials, expired token) |
+| `HTTPError` | Non-2xx HTTP response from the API |
+| `ItemNotFoundError` | Requested STAC item does not exist |
+| `CollectionError` | Collection operation fails |
+| `DeleteError` | Delete operation fails |
+| `StorageError` | Storage operation fails (upload/download) |
+| `UploadError` | File upload fails |
+| `StacValidationError` | STAC item/collection validation fails |
+| `DatacosmosError` | Base exception for all SDK errors |
+
+## Advanced Features
+
+### Request and Response Hooks
+
+You can add custom hooks to intercept requests and responses for logging, metrics, or custom processing:
+
+```python
+from datacosmos.datacosmos_client import DatacosmosClient
+
+def log_request(method, url, *args, **kwargs):
+    print(f"Request: {method} {url}")
+
+def log_response(response):
+    print(f"Response: {response.status_code}")
+
+client = DatacosmosClient(
+    config={...},
+    request_hooks=[log_request],
+    response_hooks=[log_response]
+)
 ```
 
 ## Contributing

--- a/datacosmos/__init__.py
+++ b/datacosmos/__init__.py
@@ -1,6 +1,6 @@
 """A library for interacting with DataCosmos from Python code."""
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("datacosmos")

--- a/datacosmos/config/auth/factory.py
+++ b/datacosmos/config/auth/factory.py
@@ -23,14 +23,26 @@ from datacosmos.config.models.local_user_account_authentication_config import (
     LocalUserAccountAuthenticationConfig,
 )
 from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.config.models.no_authentication_config import NoAuthenticationConfig
 from datacosmos.exceptions import AuthenticationError
 
-AuthModel = Union[M2MAuthenticationConfig, LocalUserAccountAuthenticationConfig]
+AuthModel = Union[
+    M2MAuthenticationConfig,
+    LocalUserAccountAuthenticationConfig,
+    NoAuthenticationConfig,
+]
 
 
 def parse_auth_config(raw: dict | AuthModel | None) -> Optional[AuthModel]:
     """Turn a raw dict (e.g., from YAML/env) into a concrete auth model."""
-    if isinstance(raw, (M2MAuthenticationConfig, LocalUserAccountAuthenticationConfig)):
+    if isinstance(
+        raw,
+        (
+            M2MAuthenticationConfig,
+            LocalUserAccountAuthenticationConfig,
+            NoAuthenticationConfig,
+        ),
+    ):
         return cast(Optional[AuthModel], raw)
 
     if raw is None:
@@ -42,6 +54,9 @@ def parse_auth_config(raw: dict | AuthModel | None) -> Optional[AuthModel]:
         return None
 
     auth_type = _normalize_auth_type(raw_data.get("type") or DEFAULT_AUTH_TYPE)
+
+    if auth_type == "none":
+        return NoAuthenticationConfig(type="none")
 
     if auth_type == "local":
         return LocalUserAccountAuthenticationConfig(
@@ -108,6 +123,10 @@ def apply_auth_defaults(auth: AuthModel | None) -> AuthModel:
 
 def check_required_auth_fields(auth: AuthModel) -> None:
     """Enforce required fields per auth type."""
+    if isinstance(auth, NoAuthenticationConfig):
+        # No validation needed for "none" auth type
+        return
+
     if isinstance(auth, M2MAuthenticationConfig):
         missing = [f for f in ("client_id", "client_secret") if not getattr(auth, f)]
         if missing:
@@ -129,6 +148,11 @@ def check_required_auth_fields(auth: AuthModel) -> None:
 def normalize_authentication(raw: dict | AuthModel | None) -> AuthModel:
     """End-to-end auth normalization: parse -> apply defaults -> required-field checks."""
     model = parse_auth_config(raw)
+
+    # NoAuthenticationConfig requires no further processing
+    if isinstance(model, NoAuthenticationConfig):
+        return model
+
     model = apply_auth_defaults(model)
     check_required_auth_fields(model)
     return model
@@ -137,8 +161,8 @@ def normalize_authentication(raw: dict | AuthModel | None) -> AuthModel:
 def _normalize_auth_type(value: str) -> str:
     """Return a normalized auth type or raise for unsupported values."""
     v = (value or "").strip().lower()
-    if v in {"m2m", "local"}:
+    if v in {"m2m", "local", "none"}:
         return v
     raise ValueError(
-        f"Unsupported authentication type: {value!r}. Expected 'm2m' or 'local'."
+        f"Unsupported authentication type: {value!r}. Expected 'm2m', 'local', or 'none'."
     )

--- a/datacosmos/config/config.py
+++ b/datacosmos/config/config.py
@@ -23,6 +23,7 @@ from datacosmos.config.models.local_user_account_authentication_config import (
     LocalUserAccountAuthenticationConfig,
 )
 from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.config.models.no_authentication_config import NoAuthenticationConfig
 from datacosmos.config.models.url import URL
 
 
@@ -77,7 +78,12 @@ class Config(BaseSettings):
         if raw is None:
             return None
         if isinstance(
-            raw, (M2MAuthenticationConfig, LocalUserAccountAuthenticationConfig)
+            raw,
+            (
+                M2MAuthenticationConfig,
+                LocalUserAccountAuthenticationConfig,
+                NoAuthenticationConfig,
+            ),
         ):
             return raw
         if isinstance(raw, dict):

--- a/datacosmos/datacosmos_client.py
+++ b/datacosmos/datacosmos_client.py
@@ -22,6 +22,7 @@ from datacosmos.auth.base_authenticator import BaseAuthenticator
 from datacosmos.auth.local_authenticator import LocalAuthenticator
 from datacosmos.auth.m2m_authenticator import M2MAuthenticator
 from datacosmos.config.config import Config
+from datacosmos.config.models.no_authentication_config import NoAuthenticationConfig
 from datacosmos.exceptions import AuthenticationError, DatacosmosError, HTTPError
 
 _log = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class DatacosmosClient:
         self,
         config: Optional[Config | Any] = None,
         http_session: Optional[requests.Session | OAuth2Session] = None,
+        token: Optional[str] = None,
         request_hooks: Optional[List[RequestHook]] = None,
         response_hooks: Optional[List[ResponseHook]] = None,
     ):
@@ -47,10 +49,14 @@ class DatacosmosClient:
         Args:
             config (Optional[Config]): Configuration object (only needed when SDK creates its own session).
             http_session (Optional[requests.Session]): Pre-authenticated session.
+            token (Optional[str]): A pre-obtained access token. When provided, the client
+                creates a session with a Bearer Authorization header. Cannot be combined
+                with config or http_session.
             request_hooks (Optional[List[RequestHook]]): A list of functions to be called before each request.
             response_hooks (Optional[List[ResponseHook]]): A list of functions to be called after each successful response.
         """
-        self.config = self._coerce_config(config)
+        self._validate_init_params(config, http_session, token)
+
         self.token: Optional[str] = None
         self.token_expiry: Optional[datetime] = None
         self._refresh_lock = threading.Lock()
@@ -58,14 +64,66 @@ class DatacosmosClient:
         self._request_hooks = request_hooks or []
         self._response_hooks = response_hooks or []
 
-        if http_session is not None:
-            self._init_with_injected_session(http_session)
+        if token is not None:
+            self._init_with_token(token)
             return
 
+        if http_session is not None:
+            self._init_with_injected_session(http_session, config)
+            return
+
+        self.config = self._coerce_config(config)
         self._owns_session = True
         self._http_client = self._authenticate_and_initialize_client()
 
     # --------------------------- init helpers ---------------------------
+
+    def _validate_init_params(
+        self,
+        config: Optional[Config | Any],
+        http_session: Optional[requests.Session | OAuth2Session],
+        token: Optional[str],
+    ) -> None:
+        """Validate mutual exclusivity of initialization parameters.
+
+        Args:
+            config: Configuration object.
+            http_session: Pre-authenticated session.
+            token: Pre-obtained access token.
+
+        Raises:
+            AuthenticationError: If token is combined with config or http_session.
+        """
+        if token is not None:
+            if http_session is not None:
+                raise AuthenticationError(
+                    "Cannot provide both 'token' and 'http_session'. "
+                    "Use 'token' for simple token-based auth, or 'http_session' "
+                    "for a pre-configured session."
+                )
+            if config is not None:
+                raise AuthenticationError(
+                    "Cannot provide both 'token' and 'config'. "
+                    "Use 'token' for simple token-based auth, or 'config' "
+                    "for M2M/local authentication flows."
+                )
+
+    def _init_with_token(self, token: str) -> None:
+        """Initialize the client with a pre-obtained access token.
+
+        Creates a requests.Session with the token set in the Authorization header.
+        The client will not attempt to refresh the token automatically.
+
+        Args:
+            token: The access token to use for authentication.
+        """
+        self._http_client = requests.Session()
+        self._http_client.headers.update({"Authorization": f"Bearer {token}"})
+        self._owns_session = False
+        self.token = token
+        self.token_expiry = None
+        # Use NoAuthenticationConfig to skip credential validation
+        self.config = Config(authentication=NoAuthenticationConfig(type="none"))
 
     def _coerce_config(self, cfg: Optional[Config | Any]) -> Config:
         if cfg is None:
@@ -82,10 +140,18 @@ class DatacosmosClient:
             ) from e
 
     def _init_with_injected_session(
-        self, http_session: requests.Session | OAuth2Session
+        self,
+        http_session: requests.Session | OAuth2Session,
+        config: Optional[Config | Any] = None,
     ) -> None:
         self._http_client = http_session
         self._owns_session = False
+
+        # Use NoAuthenticationConfig when no config provided (skip credential validation)
+        if config is None:
+            self.config = Config(authentication=NoAuthenticationConfig(type="none"))
+        else:
+            self.config = self._coerce_config(config)
 
         token_data = self._extract_token_data(http_session)
         self.token = token_data.get("access_token")

--- a/datacosmos/stac/item/models/datacosmos_item.py
+++ b/datacosmos/stac/item/models/datacosmos_item.py
@@ -233,14 +233,18 @@ class DatacosmosItem(BaseModel):
 
         coll_id = collection_id or self.collection
         if not coll_id:
-            raise ValueError("Cannot add self link: no collection_id provided or set on item.")
+            raise ValueError(
+                "Cannot add self link: no collection_id provided or set on item."
+            )
 
         base = base_url.rstrip("/")
-        self.links.append({
-            "rel": "self",
-            "href": f"{base}/collections/{coll_id}/items/{self.id}",
-            "type": "application/geo+json",
-        })
+        self.links.append(
+            {
+                "rel": "self",
+                "href": f"{base}/collections/{coll_id}/items/{self.id}",
+                "type": "application/geo+json",
+            }
+        )
 
     def add_parent_link(self, base_url: str, collection_id: str | None = None) -> None:
         """Add a 'parent' link to the item if not already present.
@@ -254,16 +258,22 @@ class DatacosmosItem(BaseModel):
 
         coll_id = collection_id or self.collection
         if not coll_id:
-            raise ValueError("Cannot add parent link: no collection_id provided or set on item.")
+            raise ValueError(
+                "Cannot add parent link: no collection_id provided or set on item."
+            )
 
         base = base_url.rstrip("/")
-        self.links.append({
-            "rel": "parent",
-            "href": f"{base}/collections/{coll_id}",
-            "type": "application/json",
-        })
+        self.links.append(
+            {
+                "rel": "parent",
+                "href": f"{base}/collections/{coll_id}",
+                "type": "application/json",
+            }
+        )
 
-    def ensure_standard_links(self, base_url: str, collection_id: str | None = None) -> None:
+    def ensure_standard_links(
+        self, base_url: str, collection_id: str | None = None
+    ) -> None:
         """Ensure the item has both 'self' and 'parent' links.
 
         This method adds missing links without modifying existing ones.

--- a/datacosmos/stac/project/project_item_client.py
+++ b/datacosmos/stac/project/project_item_client.py
@@ -32,9 +32,7 @@ class ProjectItemClient:
         self.client = client
         self.project_base_url = client.config.project.as_domain_url()
 
-    def list_project_items(
-        self, scenario_id: str
-    ) -> Generator[Item, None, None]:
+    def list_project_items(self, scenario_id: str) -> Generator[Item, None, None]:
         """List all items in a project/scenario.
 
         Args:
@@ -102,9 +100,7 @@ class ProjectItemClient:
         response = self.client.post(url, json=item_json)
         check_api_response(response)
 
-    def add_project_item(
-        self, scenario_id: str, item: Item | DatacosmosItem
-    ) -> None:
+    def add_project_item(self, scenario_id: str, item: Item | DatacosmosItem) -> None:
         """Add or update an item in a project/scenario (upsert).
 
         Args:

--- a/datacosmos/stac/storage/storage_client.py
+++ b/datacosmos/stac/storage/storage_client.py
@@ -148,11 +148,13 @@ class StorageClient:
                         future.result()
                         successful_assets.append(asset_key)
                     except Exception as e:
-                        failed_assets.append({
-                            "asset_key": asset_key,
-                            "error": str(e),
-                            "exception": e,
-                        })
+                        failed_assets.append(
+                            {
+                                "asset_key": asset_key,
+                                "error": str(e),
+                                "exception": e,
+                            }
+                        )
 
         # Step 3: Delete item metadata
         item_deleted = False

--- a/datacosmos/stac/validation/license.py
+++ b/datacosmos/stac/validation/license.py
@@ -43,7 +43,9 @@ def normalize_collection_license(license_value: str) -> tuple[str, str | None]:
     # Check for deprecated licenses
     if lower in DEPRECATED_LICENSES:
         replacement = DEPRECATED_LICENSES[lower]
-        warning = f'license value "{license_value}" is deprecated; mapped to "{replacement}"'
+        warning = (
+            f'license value "{license_value}" is deprecated; mapped to "{replacement}"'
+        )
         return replacement, warning
 
     if lower == "other":

--- a/tests/unit/datacosmos/datacosmos_client/test_client_token_authentication.py
+++ b/tests/unit/datacosmos/datacosmos_client/test_client_token_authentication.py
@@ -1,0 +1,126 @@
+"""Tests for token-based authentication in DatacosmosClient."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from datacosmos.config.config import Config
+from datacosmos.config.models.m2m_authentication_config import M2MAuthenticationConfig
+from datacosmos.datacosmos_client import DatacosmosClient
+from datacosmos.exceptions import AuthenticationError
+
+
+class TestClientTokenAuthentication:
+    """Test suite for DatacosmosClient token-based authentication."""
+
+    def test_token_creates_session_with_bearer_header(self):
+        """Test that providing a token creates a session with Bearer auth header."""
+        client = DatacosmosClient(token="my-access-token")
+
+        assert client.token == "my-access-token"
+        assert client._owns_session is False
+        assert client.token_expiry is None
+        assert "Authorization" in client._http_client.headers
+        assert client._http_client.headers["Authorization"] == "Bearer my-access-token"
+
+    def test_token_skips_authentication_flow(self):
+        """Test that providing a token skips the SDK authentication flow."""
+        with patch.object(
+            DatacosmosClient,
+            "_authenticate_and_initialize_client",
+            side_effect=AssertionError(
+                "Should not authenticate when token is provided"
+            ),
+        ):
+            client = DatacosmosClient(token="my-access-token")
+
+        assert client.token == "my-access-token"
+
+    def test_token_cannot_be_combined_with_config(self):
+        """Test that providing both token and config raises AuthenticationError."""
+        config = Config(
+            authentication=M2MAuthenticationConfig(
+                type="m2m",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            DatacosmosClient(token="my-access-token", config=config)
+
+        assert "Cannot provide both 'token' and 'config'" in str(exc_info.value)
+
+    def test_token_cannot_be_combined_with_http_session(self):
+        """Test that providing both token and http_session raises AuthenticationError."""
+        session = requests.Session()
+        session.headers.update({"Authorization": "Bearer existing-token"})
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            DatacosmosClient(token="my-access-token", http_session=session)
+
+        assert "Cannot provide both 'token' and 'http_session'" in str(exc_info.value)
+
+    def test_token_client_can_make_requests(self):
+        """Test that a token-authenticated client can make HTTP requests."""
+        client = DatacosmosClient(token="my-access-token")
+
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+
+        client._http_client.request = Mock(return_value=mock_response)
+
+        result = client.request("GET", "https://api.example.com/data")
+
+        assert result is mock_response
+        client._http_client.request.assert_called_once()
+        call_kwargs = client._http_client.request.call_args
+        assert call_kwargs[0] == ("GET", "https://api.example.com/data")
+
+    def test_token_client_has_default_config_for_urls(self):
+        """Test that token client uses default Config for URL endpoints."""
+        client = DatacosmosClient(token="my-access-token")
+
+        # Should have a default Config with standard URL endpoints
+        assert client.config is not None
+        assert client.config.stac.host == "app.open-cosmos.com"
+
+    def test_token_client_with_hooks(self):
+        """Test that token client works with request/response hooks."""
+        request_hook_called = []
+        response_hook_called = []
+
+        def request_hook(method, url, *args, **kwargs):
+            request_hook_called.append((method, url))
+
+        def response_hook(response):
+            response_hook_called.append(response.status_code)
+
+        client = DatacosmosClient(
+            token="my-access-token",
+            request_hooks=[request_hook],
+            response_hooks=[response_hook],
+        )
+
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+
+        client._http_client.request = Mock(return_value=mock_response)
+
+        client.request("GET", "https://api.example.com/data")
+
+        assert len(request_hook_called) == 1
+        assert request_hook_called[0] == ("GET", "https://api.example.com/data")
+        assert len(response_hook_called) == 1
+        assert response_hook_called[0] == 200
+
+    def test_token_client_does_not_refresh_token(self):
+        """Test that token client does not attempt token refresh."""
+        client = DatacosmosClient(token="my-access-token")
+
+        # _owns_session is False, so _needs_refresh should return False
+        assert client._owns_session is False
+        assert client._needs_refresh() is False


### PR DESCRIPTION
- Add 'token' parameter to DatacosmosClient for direct token-based auth
- Add 'none' authentication type to skip credential validation
- Update README with:
  - Token-based authentication documentation
  - Pre-authenticated session (http_session) documentation
  - Local user authentication documentation
  - Download assets documentation
  - delete_item_with_assets() documentation
  - Uploader.load_item() and save_item() utilities
  - Request/response hooks documentation
  - Comprehensive exception types reference