### PR TITLE
fix: correct URL defaults (internal storage host, scenario path, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ This opens a browser window for login and caches the token locally at `~/.dataco
 | `project.port`                             | `443`                                   | YAML / ENV     |
 | `project.path`                             | `/api/data/v0/scenario`                 | YAML / ENV     |
 
+> **Note:** when `datacosmos_public_cloud_storage` is not set explicitly and the
+> SDK is running outside the Open Cosmos cluster, it mirrors
+> `datacosmos_cloud_storage`, so overriding the storage URL (e.g. pointing it at
+> a test environment) automatically keeps public asset hrefs consistent. Inside
+> the cluster the external default is kept, since internal service URLs
+> are not publicly reachable.
+
 ## STAC Client
 
 The `STACClient` enables interaction with the STAC API, allowing for searching, retrieving, creating, updating, and deleting STAC items and collections.

--- a/datacosmos/config/config.py
+++ b/datacosmos/config/config.py
@@ -7,7 +7,7 @@ and supports environment variable-based overrides.
 
 from typing import Optional
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from datacosmos.config.auth.factory import normalize_authentication, parse_auth_config
@@ -16,6 +16,7 @@ from datacosmos.config.environment import (
     get_default_project,
     get_default_stac,
     get_default_storage,
+    is_running_in_opencosmos_cluster,
 )
 from datacosmos.config.loaders.yaml_source import yaml_settings_source
 from datacosmos.config.models.authentication_config import AuthenticationConfig
@@ -74,6 +75,24 @@ class Config(BaseSettings):
             file_secret_settings,
         ]
         return tuple(s for s in sources if s is not None)
+
+    @model_validator(mode="after")
+    def _default_public_storage_from_storage(self):
+        """Mirror datacosmos_cloud_storage unless public storage is set explicitly.
+
+        Outside the cluster datacosmos_cloud_storage is the external,
+        per-environment URL, so it is also the correct public URL. Inside the
+        cluster datacosmos_cloud_storage resolves to an internal service URL
+        that is not publicly reachable, so the external default is kept there.
+        """
+        if (
+            "datacosmos_public_cloud_storage" not in self.model_fields_set
+            and not is_running_in_opencosmos_cluster()
+        ):
+            self.datacosmos_public_cloud_storage = (
+                self.datacosmos_cloud_storage.model_copy()
+            )
+        return self
 
     @field_validator("authentication", mode="before")
     @classmethod

--- a/datacosmos/config/constants.py
+++ b/datacosmos/config/constants.py
@@ -33,7 +33,10 @@ DEFAULT_STORAGE_EXTERNAL = dict(
     protocol="https", host="app.open-cosmos.com", port=443, path="/api/data/v0/storage"
 )
 DEFAULT_PROJECT = dict(
-    protocol="https", host="app.open-cosmos.com", port=443, path="/api/data/v0"
+    protocol="https",
+    host="app.open-cosmos.com",
+    port=443,
+    path="/api/data/v0/scenario",
 )
 
 # Internal URLs (used inside Kubernetes cluster)
@@ -42,7 +45,7 @@ DEFAULT_STAC_INTERNAL = dict(
 )
 DEFAULT_STORAGE_INTERNAL = dict(
     protocol="http",
-    host="storage.default.svc.cluster.local",
+    host="datacosmos-file-storage.default.svc.cluster.local",
     port=80,
     path="/",
 )

--- a/tests/unit/config/k8s_detection/test_config_with_k8s_detection.py
+++ b/tests/unit/config/k8s_detection/test_config_with_k8s_detection.py
@@ -16,7 +16,9 @@ class TestConfigWithOpenCosmosClusterDetection:
         """Clean environment before each test."""
         monkeypatch.delenv(OPENCOSMOS_INTERNAL_CLUSTER_ENV, raising=False)
         for k in list(os.environ):
-            if k.startswith(("AUTHENTICATION__", "STAC__", "DATACOSMOS_", "OPENCOSMOS_")):
+            if k.startswith(
+                ("AUTHENTICATION__", "STAC__", "DATACOSMOS_", "OPENCOSMOS_")
+            ):
                 monkeypatch.delenv(k, raising=False)
 
     def test_config_uses_external_urls_outside_oc_cluster(self, tmp_path, monkeypatch):
@@ -76,13 +78,18 @@ class TestConfigWithOpenCosmosClusterDetection:
         assert cfg.stac.path == "/"
 
         assert cfg.datacosmos_cloud_storage.protocol == "http"
-        assert cfg.datacosmos_cloud_storage.host == "storage.default.svc.cluster.local"
+        assert (
+            cfg.datacosmos_cloud_storage.host
+            == "datacosmos-file-storage.default.svc.cluster.local"
+        )
 
         # Public cloud storage should always use external URLs (for public asset hrefs)
         assert cfg.datacosmos_public_cloud_storage.protocol == "https"
         assert cfg.datacosmos_public_cloud_storage.host == "app.open-cosmos.com"
 
-    def test_explicit_config_overrides_oc_cluster_detection(self, tmp_path, monkeypatch):
+    def test_explicit_config_overrides_oc_cluster_detection(
+        self, tmp_path, monkeypatch
+    ):
         """Explicit YAML config should override auto-detected URLs."""
         monkeypatch.setenv(OPENCOSMOS_INTERNAL_CLUSTER_ENV, "true")
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -13,8 +13,10 @@ from datacosmos.exceptions import AuthenticationError
 ALL_CONFIG_ENV_PREFIXES = [
     "AUTHENTICATION__",
     "STAC__",
-    "DATACOSMOS_DATACOSMOS_CLOUD_STORAGE__",
-    "DATACOSMOS_DATACOSMOS_PUBLIC_CLOUD_STORAGE__",
+    "DATACOSMOS_CLOUD_STORAGE__",
+    "DATACOSMOS_PUBLIC_CLOUD_STORAGE__",
+    "PROJECT__",
+    "OPENCOSMOS_",
 ]
 
 
@@ -170,6 +172,67 @@ class TestConfig:
             443,
             "/api/data/v0/storage",
         )
+
+    def test_project_defaults_applied_when_missing(self):
+        """Test project falls back to the external scenario service defaults."""
+        cfg = Config(authentication={"client_id": "id", "client_secret": "secret"})
+        p = cfg.project
+        assert isinstance(p, URL)
+        assert (p.protocol, p.host, p.port, p.path) == (
+            "https",
+            "app.open-cosmos.com",
+            443,
+            "/api/data/v0/scenario",
+        )
+
+    def test_public_cloud_storage_mirrors_cloud_storage_when_not_set(
+        self, monkeypatch, tmp_path
+    ):
+        """Public storage follows datacosmos_cloud_storage outside the cluster."""
+        monkeypatch.setattr(
+            "datacosmos.config.config.DEFAULT_CONFIG_YAML",
+            str(tmp_path / "does_not_exist.yaml"),
+            raising=True,
+        )
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PROTOCOL", "https")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__HOST", "test.app.open-cosmos.com")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PORT", "443")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PATH", "/api/data/v0/storage")
+
+        cfg = Config(authentication={"client_id": "id", "client_secret": "secret"})
+
+        s = cfg.datacosmos_public_cloud_storage
+        assert (s.protocol, s.host, s.port, s.path) == (
+            "https",
+            "test.app.open-cosmos.com",
+            443,
+            "/api/data/v0/storage",
+        )
+
+    def test_public_cloud_storage_explicit_value_wins(self, monkeypatch, tmp_path):
+        """An explicit public storage setting is never overridden by mirroring."""
+        monkeypatch.setattr(
+            "datacosmos.config.config.DEFAULT_CONFIG_YAML",
+            str(tmp_path / "does_not_exist.yaml"),
+            raising=True,
+        )
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PROTOCOL", "https")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__HOST", "test.app.open-cosmos.com")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PORT", "443")
+        monkeypatch.setenv("DATACOSMOS_CLOUD_STORAGE__PATH", "/api/data/v0/storage")
+        monkeypatch.setenv("DATACOSMOS_PUBLIC_CLOUD_STORAGE__PROTOCOL", "https")
+        monkeypatch.setenv(
+            "DATACOSMOS_PUBLIC_CLOUD_STORAGE__HOST", "public.example.com"
+        )
+        monkeypatch.setenv("DATACOSMOS_PUBLIC_CLOUD_STORAGE__PORT", "443")
+        monkeypatch.setenv(
+            "DATACOSMOS_PUBLIC_CLOUD_STORAGE__PATH", "/api/data/v0/storage"
+        )
+
+        cfg = Config(authentication={"client_id": "id", "client_secret": "secret"})
+
+        assert cfg.datacosmos_public_cloud_storage.host == "public.example.com"
+        assert cfg.datacosmos_cloud_storage.host == "test.app.open-cosmos.com"
 
     def test_local_auth_defaults_applied(self):
         """Test local authentication fields are correctly defaulted by the factory."""


### PR DESCRIPTION
## Summary

Three SDK URL defaults didn't match the deployed platform, breaking out-of-the-box use:

- **Internal storage host**: `storage.default.svc.cluster.local` → `datacosmos-file-storage.default.svc.cluster.local` (the actual service name in all clusters; `catalog` and `stac-scenario-service` were already correct).
- **External project path**: `/api/data/v0` → `/api/data/v0/scenario`, where the gateway mounts the scenario service. Matches the README, which already documented the correct path.
- **Public cloud storage is no longer pinned to prod**: when `datacosmos_public_cloud_storage` isn't set explicitly and the SDK runs outside the cluster, it now mirrors `datacosmos_cloud_storage`, so pointing the SDK at another environment keeps asset hrefs consistent. Explicit YAML/env settings still win; in-cluster the external default is kept (internal URLs aren't publicly reachable).
